### PR TITLE
Fix config.toml property for logging always being overwritten by argparse default

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.app_name}}/cli.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.app_name}}/cli.py
@@ -28,7 +28,7 @@ def main(argv=None) -> int:
     if args.warn:
         config.core.logging = args.warn
     logger.stop()  # clear handlers to prevent duplicate records
-    logger.start(config.core.logging)
+    logger.start(config.core.get("logging")) # dict.get() enables logger arg defaults
     command = args.command
     args = vars(args)
     spec = getfullargspec(command)
@@ -55,8 +55,8 @@ def _args(argv):
     parser.add_argument("-v", "--version", action="version",
             version=f"{{ cookiecutter.app_name }} {__version__}",
             help="print version and exit")
-    parser.add_argument("-w", "--warn", default="WARNING",
-            help="logger warning level [WARNING]")
+    parser.add_argument("-w", "--warn", # default not needed due to logger.start having default
+            help="logger warning level [WARN]")
     parser.set_defaults(command=None)
     subparsers = parser.add_subparsers(title="subcommands")
     common = ArgumentParser(add_help=False)  # common subcommand arguments

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.app_name}}/core/logger.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.app_name}}/core/logger.py
@@ -16,6 +16,7 @@ class _Logger(getLoggerClass()):
 
     """
     LOGFMT = "%(asctime)s;%(levelname)s;%(name)s;%(message)s"
+    DFLTLEVEL = "WARN"
 
     def __init__(self, name=None):
         """ Initialize this logger.
@@ -34,7 +35,7 @@ class _Logger(getLoggerClass()):
         self.addHandler(NullHandler())  # default to no output
         return
 
-    def start(self, level="WARN", stream=None):
+    def start(self, level=DFLTLEVEL, stream=None):
         """ Start logging to a stream.
 
         Until the logger is started, no messages will be emitted. This applies
@@ -59,7 +60,7 @@ class _Logger(getLoggerClass()):
         :param level: logger priority level
         :param stream: output stream (stderr by default)
         """
-        self.setLevel(level.upper() if level is not None else "WARN")
+        self.setLevel(level.upper() if level is not None else self.DFLTLEVEL)
         handler = StreamHandler(stream)
         handler.setFormatter(Formatter(self.LOGFMT))
         handler.setLevel(self.level)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.app_name}}/core/logger.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.app_name}}/core/logger.py
@@ -59,7 +59,7 @@ class _Logger(getLoggerClass()):
         :param level: logger priority level
         :param stream: output stream (stderr by default)
         """
-        self.setLevel(level.upper())
+        self.setLevel(level.upper() if level is not None else "WARN")
         handler = StreamHandler(stream)
         handler.setFormatter(Formatter(self.LOGFMT))
         handler.setLevel(self.level)


### PR DESCRIPTION
Enable default WARN log level while adding support for property-less config file.

* Remove default from argparse `--warn`.
* Add NoneGuard to `logger.start()`.
    * Enables default behaviour when given `level=None`.
* Utilize `dict.get()` when accessing config.toml's "logging" property.
    * Increases flexibility of property file.
    * No longer required to have logging as a property.
